### PR TITLE
Add RSS content type

### DIFF
--- a/feed.php
+++ b/feed.php
@@ -1,4 +1,9 @@
 <?php
+	if (strpos($_SERVER["HTTP_ACCEPT"], "application/rss+xml") !== FALSE)
+		header("Content-Type: application/rss+xml");
+	else
+		header("Content-Type: application/xml");
+
 	$user = $_GET["user"];
 
 	$notesContent = file_get_contents("https://api.openstreetmap.org/api/0.6/notes/search?display_name=".urlencode($user)."&closed=7");


### PR DESCRIPTION
This makes a web browser not attempt to render the page as HTML file but instead render it as XML or for feed readers expecting RSS pages properly respond with the RSS mime type